### PR TITLE
Update podspec patch version number

### DIFF
--- a/PNChart.podspec
+++ b/PNChart.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "PNChart"
-  s.version      = "0.8.9"
+  s.version      = "0.8.10"
   s.summary      = "A simple and beautiful chart lib with animation used in Piner for iOS"
 
   s.description  = <<-DESC


### PR DESCRIPTION
Changes that silence compiler warnings have been added since the last patch version but the podspec hasn't been updated.